### PR TITLE
feat: formatDateInTimeZone  for formatting dates in specific timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn add world-clockify
 After installation, you can use the library as follows:
 
 ```javascript
-import { convertTimeZone, getCurrentTimeInZone, getTimeDifference } from 'world-clockify';
+import { convertTimeZone, getCurrentTimeInZone, getTimeDifference, formatDateInTimeZone } from 'world-clockify';
 
 // Convert time between timezones
 const convertedTime = convertTimeZone('2024-01-01T12:00:00', 'America/New_York', 'Europe/London');
@@ -44,4 +44,12 @@ console.log(currentTime); // Outputs the current time in ISO format
 // Calculate time difference between two timezones
 const timeDifference = getTimeDifference('America/New_York', 'Europe/London');
 console.log(timeDifference); // Outputs: 5 (hours)
+
+const dateStr = '2024-10-14T12:00:00';
+const fromZone = 'UTC';
+const toZone = 'America/New_York';
+const format = 'MM/dd/yyyy HH:mm';
+
+// Example usage:
+console.log(formatDateInTimeZone(dateStr, fromZone, toZone, format)); //output: 10/14/2024 08:00
 ```

--- a/src/function.ts
+++ b/src/function.ts
@@ -36,3 +36,16 @@ export const getTimeDifference = (timezone1: string, timezone2: string): number 
 
   return diffInHours;
 };
+
+/**
+ * Formats a date string for a given timezone in the specified format.
+ * @param {string} dateStr - The date string in ISO format.
+ * @param {string} fromZone - The source timezone.
+ * @param {string} toZone - The target timezone.
+ * @param {string} format - The format string for the output date.
+ * @returns {string} - The formatted date string in the target timezone.
+ */
+
+export const formatDateInTimeZone = (dateStr: string, fromZone: string, toZone: string, format: string): string => {
+  return DateTime.fromISO(dateStr, { zone: fromZone }).setZone(toZone).toFormat(format);
+};

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { convertTimeZone, getCurrentTimeInZone, getTimeDifference } from '../src/function.js';
+import { describe, it, expect, should } from 'vitest';
+import { convertTimeZone, getCurrentTimeInZone, getTimeDifference, formatDateInTimeZone } from '../src/function.js';
 
 describe('Timezone-Aware Date Helper', () => {
   it('should convert date between timezones', () => {
@@ -16,5 +16,25 @@ describe('Timezone-Aware Date Helper', () => {
   it('should calculate time difference between two timezones', () => {
     const diff = getTimeDifference('America/New_York', 'Europe/London');
     expect(diff).toBe(5); // Assuming DST is not in effect.
+  });
+
+  it('should format date correct for a different timezone', () => {
+    const dateStr = '2024-10-14T12:00:00';
+    const fromZone = 'UTC';
+    const toZone = 'America/New_York';
+    const format = 'MM/dd/yyyy HH:mm';
+
+    const result = formatDateInTimeZone(dateStr, fromZone, toZone, format);
+    expect(result).toBe('10/14/2024 08:00');
+  });
+
+  it('should handle other timezones and format correctly', () => {
+    const dateStr = '2024-10-14T12:00:00';
+    const fromZone = 'UTC';
+    const toZone = 'Asia/Tokyo';
+    const format = 'yyyy-MM-dd HH:mm';
+
+    const result = formatDateInTimeZone(dateStr, fromZone, toZone, format);
+    expect(result).toBe('2024-10-14 21:00');
   });
 });


### PR DESCRIPTION
This will allow users to format a date in any timezone and in various formats (e.g., `ISO`, custom formats like `MM/dd/yyyy HH:mm`).

fixes: #1 