### PR TITLE
feat: add validation for timezones and date string with detailed error

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon';
+import { DateTime, IANAZone } from 'luxon';
 
 /**
  * Converts a date from one timezone to another.
@@ -8,7 +8,36 @@ import { DateTime } from 'luxon';
  * @returns {string} - The converted date in the target timezone.
  */
 export const convertTimeZone = (dateStr: string, fromZone: string, toZone: string): string => {
-  return DateTime.fromISO(dateStr, { zone: fromZone }).setZone(toZone).toISO()!;
+  const dateTime = DateTime.fromISO(dateStr, { zone: fromZone });
+
+  // Debug: Print the original date with timezone info
+  console.log('Original DateTime:', dateTime.toString());
+
+  if (!IANAZone.isValidZone(fromZone)) {
+    throw new Error(
+      `Invalid source timezone: "${fromZone}". Please provide a valid IANA timezone (e.g., 'America/New_York').`,
+    );
+  }
+
+  // Validate the target timezone
+  if (!IANAZone.isValidZone(toZone)) {
+    throw new Error(
+      `Invalid target timezone: "${toZone}". Please provide a valid IANA timezone (e.g., 'Europe/London').`,
+    );
+  }
+
+  if (!dateTime.isValid) {
+    throw new Error(
+      `Invalid date string: "${dateStr}". Ensure the date is in ISO format (e.g., 'YYYY-MM-DDTHH:mm:ss').`,
+    );
+  }
+
+  const converted = dateTime.setZone(toZone);
+
+  // Debug: Print the converted date with timezone info
+  console.log('Converted DateTime:', converted.toString());
+
+  return converted.toISO()!;
 };
 
 /**
@@ -17,7 +46,20 @@ export const convertTimeZone = (dateStr: string, fromZone: string, toZone: strin
  * @returns {string} - The current time in ISO format for the given timezone.
  */
 export const getCurrentTimeInZone = (timezone: string): string => {
-  return DateTime.now().setZone(timezone).toISO()!;
+  if (!IANAZone.isValidZone(timezone)) {
+    throw new Error(
+      `Invalid timezone: "${timezone}". Please provide a valid IANA timezone (e.g., 'America/New_York').`,
+    );
+  }
+  // Get the current time in the specified timezone
+  const currentTime = DateTime.now().setZone(timezone);
+  console.log('Current DateTime in Zone:', currentTime.toString());
+
+  // Return the current time in ISO format
+  const currentTimeISO = currentTime.toISO();
+  console.log('Current DateTime in ISO Format:', currentTimeISO);
+
+  return currentTimeISO ?? '';
 };
 
 /**
@@ -27,12 +69,26 @@ export const getCurrentTimeInZone = (timezone: string): string => {
  * @returns {number} - Time difference in hours.
  */
 export const getTimeDifference = (timezone1: string, timezone2: string): number => {
+  if (!IANAZone.isValidZone(timezone1)) {
+    throw new Error(
+      `Invalid first timezone: "${timezone1}". Please provide a valid IANA timezone (e.g., 'America/New_York').`,
+    );
+  }
+
+  if (!IANAZone.isValidZone(timezone2)) {
+    throw new Error(
+      `Invalid second timezone: "${timezone2}". Please provide a valid IANA timezone (e.g., 'Asia/Kolkata').`,
+    );
+  }
+
   const now = DateTime.now();
   const zone1 = now.setZone(timezone1);
   const zone2 = now.setZone(timezone2);
 
   // Calculate the difference in offsets
   const diffInHours = (zone2.offset - zone1.offset) / 60;
+  //Debug: Print differences
+  console.log(`Difference in offsets between ${timezone1} and ${timezone2} in hours is:`, diffInHours);
 
   return diffInHours;
 };
@@ -47,5 +103,35 @@ export const getTimeDifference = (timezone1: string, timezone2: string): number 
  */
 
 export const formatDateInTimeZone = (dateStr: string, fromZone: string, toZone: string, format: string): string => {
-  return DateTime.fromISO(dateStr, { zone: fromZone }).setZone(toZone).toFormat(format);
+  if (!IANAZone.isValidZone(fromZone)) {
+    throw new Error(
+      `Invalid source timezone: "${fromZone}". Please provide a valid IANA timezone (e.g., 'America/New_York').`,
+    );
+  }
+
+  if (!IANAZone.isValidZone(toZone)) {
+    throw new Error(
+      `Invalid target timezone: "${toZone}". Please provide a valid IANA timezone (e.g., 'Europe/London').`,
+    );
+  }
+
+  const dateTime = DateTime.fromISO(dateStr, { zone: fromZone });
+  console.log('Original DateTime:', dateTime.toString());
+
+  // Validate the date-time object
+  if (!dateTime.isValid) {
+    throw new Error(
+      `Invalid date string: "${dateStr}". Ensure the date is in ISO format (e.g., 'YYYY-MM-DDTHH:mm:ss').`,
+    );
+  }
+
+  // Convert to target timezone
+  const converted = dateTime.setZone(toZone);
+  console.log('Converted DateTime:', converted.toString());
+
+  // Format the converted date
+  const formattedDate = converted.toFormat(format);
+  console.log('Formatted DateTime:', formattedDate);
+
+  return formattedDate;
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -4,8 +4,11 @@ import { convertTimeZone, getCurrentTimeInZone, getTimeDifference, formatDateInT
 describe('Timezone-Aware Date Helper', () => {
   it('should convert date between timezones', () => {
     const dateStr = '2024-01-01T12:00:00';
-    const converted = convertTimeZone(dateStr, 'America/New_York', 'Europe/London');
-    expect(converted).toBe('2024-01-01T17:00:00.000+00:00'); // Adjusted expected value
+    const fromZone = 'America/New_York';
+    const toZone = 'Europe/London';
+
+    const converted = convertTimeZone(dateStr, fromZone, toZone);
+    expect(converted).toBe('2024-01-01T17:00:00.000+00:00');
   });
 
   it('should get current time in a specific timezone', () => {


### PR DESCRIPTION
Add validation for timezones and date string with detailed error

- Validate source and target timezones using IANAZone.isValidZone
- Provide clear error messages for invalid timezones
- Validate the date string and ensure it is in ISO format
- Add detailed logging for debugging purposes

fixes: #6 